### PR TITLE
Change Target Framework to .NET Standard 2.0 to increase project compatibility

### DIFF
--- a/Emmersion.InfluxDB/Emmersion.InfluxDB.csproj
+++ b/Emmersion.InfluxDB/Emmersion.InfluxDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Company>Emmersion</Company>
     <Description>A library for sending data to InfluxDB.</Description>
     <Copyright>Copyright (c) 2021 Emmersion</Copyright>


### PR DESCRIPTION
Changing the Target Framework to .NET Standard 2.0 will still allow the project to build, pass all tests, and be used to send data to InfluxDB, and it has the benefit of increasing project compatibility so that more projects, including .NET Framework-based projects, can install this library as a NuGet dependency. Thank you for considering this suggestion! 🙇